### PR TITLE
Prevent immediate crash on startup of debug builds signed to run locally

### DIFF
--- a/macOS-src/osxUtils/xlMacUtils.mm
+++ b/macOS-src/osxUtils/xlMacUtils.mm
@@ -582,7 +582,9 @@ bool IsFromAppStore() {
 
         CFArrayRef certChain = (CFArrayRef)CFDictionaryGetValue(info, kSecCodeInfoCertificates);
         SecCertificateRef cert = SecCertificateRef(CFArrayGetValueAtIndex(certChain, 0));
-        
+        if (cert == NULL) {    // Signed to run locally
+            return false;
+        }
         CFStringRef cn;
         SecCertificateCopyCommonName(cert, &cn);
         NSString *cnnss = (NSString *)cn;


### PR DESCRIPTION
Debug builds of xLights will crash immediately if the "sign to run locally" build option in XCode is chosen as a result of a null pointer dereference in the `IsFromAppStore()` function.

This PR adds a test to return that the build is a non-appstore build if there is no signing certificate chain at all.